### PR TITLE
Add guidance for refreshing cached registry copies

### DIFF
--- a/draft-nottingham-dnsop-censorship-transparency.md
+++ b/draft-nottingham-dnsop-censorship-transparency.md
@@ -150,7 +150,9 @@ For example:
 https://resolver.example.com/filtering-incidents/{id}
 ~~~
 
-Applications MUST store a local copy of the DNS Filtering Database Registry ({{registry}}) for purposes of template lookup; they MUST NOT query the IANA registry upon each use. The registry is keyed by the Filtering Database Operator ID.
+Applications MUST store a local copy of the DNS Filtering Database Registry ({{registry}}) for purposes of template lookup; they MUST NOT query the IANA registry upon each use.
+Applications SHOULD refresh their local copy of the registry on a periodic basis using a cached retrieval mechanism (e.g., conditional requests) and appropriate rate limiting. When the registry cannot be refreshed, applications SHOULD continue using the last known good copy. Applications MUST ignore unknown or malformed registry entries.
+ The registry is keyed by the Filtering Database Operator ID.
 
 
 # IANA Considerations


### PR DESCRIPTION
This PR adds short operational guidance for applications maintaining a local cached copy of the DNS Filtering Database Registry.

It suggests periodic refresh using cached retrieval (e.g., conditional requests) with rate limiting, continuing to use the last known good copy when refresh fails, and ignoring unknown or malformed registry entries.

No protocol behavior changes are intended.